### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0](https://github.com/natemcintosh/bit-board/compare/v0.2.1...v0.3.0) - 2025-10-10
+
+### Other
+
+- Add max sized board ([#5](https://github.com/natemcintosh/bit-board/pull/5))
+- Add max sized board ([#3](https://github.com/natemcintosh/bit-board/pull/3))
 - Changed name of `BitBoard` struct to `BitBoardDyn`
 
 ## [0.2.1](https://github.com/natemcintosh/bit-board/compare/v0.2.0...v0.2.1) - 2025-10-07

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "bit-board"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bitvec",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-board"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = "A lightweight wrapper over bitvec for 2D bit array operations"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `bit-board`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `bit-board` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct bit_board::BitBoard, previously in file /tmp/.tmpV4vi6f/bit-board/src/lib.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/natemcintosh/bit-board/compare/v0.2.1...v0.3.0) - 2025-10-10

### Other

- Add max sized board ([#5](https://github.com/natemcintosh/bit-board/pull/5))
- Add max sized board ([#3](https://github.com/natemcintosh/bit-board/pull/3))
- Changed name of `BitBoard` struct to `BitBoardDyn`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).