### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/natemcintosh/bit-board/compare/v0.4.2...v0.4.3) - 2025-11-01
+
+### Other
+
+- clippy cleanup ([#9](https://github.com/natemcintosh/bit-board/pull/9))
+
 ## [0.4.2](https://github.com/natemcintosh/bit-board/compare/v0.4.1...v0.4.2) - 2025-11-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "bit-board"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bitvec",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-board"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "A lightweight wrapper over bitvec for 2D bit array operations"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `bit-board`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/natemcintosh/bit-board/compare/v0.4.2...v0.4.3) - 2025-11-01

### Other

- clippy cleanup ([#9](https://github.com/natemcintosh/bit-board/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).